### PR TITLE
Replace rex debug logging calls with comments.

### DIFF
--- a/lib/rex/ole/directory.rb
+++ b/lib/rex/ole/directory.rb
@@ -51,20 +51,20 @@ class Directory < DirEntry
     # link item to siblings and/or parent
     if (parent._sidChild == DIR_NOSTREAM)
       parent._sidChild = child.sid
-      dlog("Linking #{child.name} as THE child of #{parent.name} as sid #{child.sid}", 'rex', LEV_3)
+      # Linking 'child' as THE child of 'parent', sid is child.sid...
     else
       sib = nil
       parent.each { |el|
         if (el._sidLeftSib == DIR_NOSTREAM)
           sib = el
           el._sidLeftSib = child.sid
-          dlog("Linking #{child.name} as the LEFT sibling of #{sib.name} as sid #{child.sid}", 'rex', LEV_3)
+          # Linking 'child' as the LEFT sibling of 'sib', sid is child.sid...
           break
         end
         if (el._sidRightSib == DIR_NOSTREAM)
           sib = el
           el._sidRightSib = child.sid
-          dlog("Linking #{child.name} as the RIGHT sibling of #{sib.name} as sid #{child.sid}", 'rex', LEV_3)
+          # Linking 'child' as the RIGHT sibling of 'sib', sid is child.sid...
           break
         end
       }
@@ -152,7 +152,6 @@ class Directory < DirEntry
   # recursively add entries to their proper parents :)
   def populate_children(entries, parent, sid)
     node = entries[sid]
-    dlog("populate_children(entries, \"#{parent.name}\", #{sid}) - node: #{node.name}", 'rex', LEV_3)
     parent << node
     if (node.type == STGTY_STORAGE) and (node._sidChild != DIR_NOSTREAM)
       populate_children(entries, node, node._sidChild)
@@ -178,7 +177,6 @@ class Directory < DirEntry
     # flatten the directory again
     entries = []
     flatten_tree(entries, self)
-    dlog("flattened tree has #{entries.length} entries...", 'rex', LEV_3)
 
     # count directory sectors
     ds_count = entries.length / 4
@@ -198,7 +196,7 @@ class Directory < DirEntry
       next if (de.type == STGTY_ROOT)
 
       dir = de.pack
-      dlog("writing dir entry #{de.name}", 'rex', LEV_3)
+      # Writing dir entry de...
       sbuf << dir
 
       if (sbuf.length == @stg.header.sector_size)

--- a/lib/rex/ole/storage.rb
+++ b/lib/rex/ole/storage.rb
@@ -126,7 +126,7 @@ class Storage
     stm = Stream.new self
     stm.name = name
     parent_stg ||= @directory
-    dlog("Adding stream #{name} to storage #{parent_stg.name}", 'rex', LEV_3)
+    # Adding stream 'name' to storage parent_stg...
     @directory.link_item(parent_stg, stm)
     @modified = true
     stm
@@ -150,7 +150,7 @@ class Storage
     stg = SubStorage.new self
     stg.name = name
     parent_stg ||= @directory
-    dlog("Adding storage #{name} to storage #{parent_stg.name}", 'rex', LEV_3)
+    # Adding storage 'name' to storage parent_stg...
     @directory.link_item(parent_stg, stg)
     stg
   end
@@ -209,7 +209,7 @@ class Storage
   end
 
   def write_sector_raw(sect, sbuf)
-    dlog("Writing sector 0x%02x" % sect, 'rex', LEV_3)
+    # Writing sector 'sect'...
     @fd.seek((sect + 1) * @header.sector_size, ::IO::SEEK_SET)
     @fd.write(sbuf)
   end
@@ -236,7 +236,7 @@ class Storage
   end
 
   def write_mini_sector_raw(sect, sbuf)
-    dlog("Writing mini sector 0x%02x" % sect, 'rex', LEV_3)
+    # Writing mini sector 'sect'...
     @ministream << sbuf
   end
 
@@ -257,7 +257,7 @@ class Storage
   end
 
   def write_stream(stm)
-    dlog("Writing \"%s\" to regular stream" % stm.name, 'rex', LEV_3)
+    # Writing 'stm.name' to regular stream...
     stm_start = nil
     prev_sect = nil
     stm.seek(0)
@@ -270,7 +270,7 @@ class Storage
   end
 
   def write_mini_stream(stm)
-    dlog("Writing \"%s\" to mini stream" % stm.name, 'rex', LEV_3)
+    # Writing 'stm.name' to mini stream...
     prev_sect = nil
     stm.seek(0)
     while (sbuf = stm.read(@header.mini_sector_size))
@@ -306,7 +306,7 @@ class Storage
       block = left if (block > left)
 
       # read it.
-      dlog("read_data - reading 0x%x bytes" % block, 'rex', LEV_3)
+      # Reading 'block' number of bytes...
       buf = read_sector(sect, block)
       ret << buf
       left -= buf.length
@@ -335,7 +335,7 @@ class Storage
       block = left if (block > left)
 
       # read it.
-      dlog("read_data_mini - reading 0x%x bytes" % block, 'rex', LEV_3)
+      # Reading 'block' number of bytes...
       buf = read_mini_sector(sect, block)
       ret << buf
       left -= buf.length
@@ -373,9 +373,9 @@ class Storage
 
 
   def read_mini_sector(sect, len)
-    dlog("Reading mini sector 0x%x" % sect, 'rex', LEV_3)
+    # Reading mini sector 'sect'...
     off = (@header.mini_sector_size * sect)
-    dlog("Reading from offset 0x%x of ministream" % off, 'rex', LEV_3)
+    # Reading from offset 'off' of ministream...
     @ministream.seek(off)
     data = @ministream.read(len)
     data


### PR DESCRIPTION
Per MS-1712, some debug logging calls made it into the initial cut of this gem.  Ideally, we'd have a logging gem, but we're not there yet.  As these are just debug logging messages, we made the call to convert those that were explanatory into comments.
